### PR TITLE
user - 회원정보 변경 메소드 리팩토링

### DIFF
--- a/app/src/main/java/com/cityCatTarot/domain/User.java
+++ b/app/src/main/java/com/cityCatTarot/domain/User.java
@@ -47,8 +47,22 @@ public class User {
      * @param source 변경할 사용자 정보
      */
     public void changeWith(User source) {
-        nickName = source.nickName;
-        password = source.password;
+
+        if(source.getNickName() != null && source.getPassword() != null){
+            nickName = source.nickName;
+            password = source.password;
+            return;
+        }
+
+        if(source.getNickName() != null){
+            nickName = source.nickName;
+            return;
+        }
+
+        if(source.getPassword() != null){
+            password = source.password;
+            return;
+        }
     }
 
     /**


### PR DESCRIPTION
닉네임과 비밀번호를 한 번에 변경하지 않고, 각각 변경할 수 있도록 메소드를 수정하였습니다.